### PR TITLE
Undefined name: import warnings for line 143

### DIFF
--- a/deep_privacy/metrics/fid.py
+++ b/deep_privacy/metrics/fid.py
@@ -7,6 +7,7 @@ import numpy as np
 import glob
 import os
 from scipy import linalg
+import warnings
 from deep_privacy.torch_utils import to_cuda
 from tqdm import tqdm, trange
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/hukkelas/DeepPrivacy on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./deep_privacy/dataset_tools/legacy/ffhq/ffhq_data_to_torch.py:97:17: F821 undefined name 'LANDMARKS_TOTAL_FILE'
    landmarks = LANDMARKS_TOTAL_FILE.loc[image_ids].values
                ^
./deep_privacy/dataset_tools/fdf/generate_dataset.py:105:56: F821 undefined name 'y1'
    assert width == height, f"width: {width}, height: {y1-y0}"
                                                       ^
./deep_privacy/dataset_tools/fdf/generate_dataset.py:105:59: F821 undefined name 'y0'
    assert width == height, f"width: {width}, height: {y1-y0}"
                                                          ^
./deep_privacy/metrics/fid.py:142:9: F821 undefined name 'warnings'
        warnings.warn(msg)
        ^
4     F821 undefined name 'y1'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree