### PR TITLE
Add possibility to replace the content of the face in the output image

### DIFF
--- a/deep_privacy/inference/anonymize_folder.py
+++ b/deep_privacy/inference/anonymize_folder.py
@@ -5,6 +5,6 @@ if __name__ == "__main__":
     generator, imsize, source_path, image_paths, save_path = infer.read_args()
 
     anonymizer = deep_privacy_anonymizer.DeepPrivacyAnonymizer(
-        generator, 128, use_static_z=True)
+        generator, 128, use_static_z=True, replace_tight_bbox=True)
 
     anonymizer.anonymize_folder(source_path, save_path)

--- a/deep_privacy/inference/anonymize_video.py
+++ b/deep_privacy/inference/anonymize_video.py
@@ -10,7 +10,8 @@ if __name__ == "__main__":
     a = deep_privacy_anonymizer.DeepPrivacyAnonymizer(generator, 32,
                                                       use_static_z=True,
                                                       keypoint_threshold=.1,
-                                                      face_threshold=.6)
+                                                      face_threshold=.6,
+                                                      replace_tight_bbox=True)
 
     a.anonymize_video(source_path,
                       target_path,

--- a/deep_privacy/inference/infer.py
+++ b/deep_privacy/inference/infer.py
@@ -108,7 +108,7 @@ def stitch_face(im, expanded_bbox, generated_face, bbox_to_extract, image_mask, 
     if tight_stitch:
         original_bbox_mask =  np.zeros_like(image_mask, dtype=bool)
         original_bbox_mask[y0:y1, x0:x1, :] = 1
-        original_bbox_mask = original_bbox_mask * image_mask # logical and on masks
+        original_bbox_mask = np.logical_and(original_bbox_mask, image_mask)
         mask_single_face = original_bbox_mask[y0e:y1e, x0e:x1e]
 
     else:


### PR DESCRIPTION
The current way of stitching the image leads to artifacts due to resizing in case of faces that are big compared to the size of the original image.
This PR adds the possibility to apply changes only to the face bbox instead of the extended face bbox in order to prevent those artifacts by setting `replace_tight_bbox` at `DeepPrivacyAnonymizer` object creation
