### PR TITLE
Fix generator in case there is no detected face

### DIFF
--- a/deep_privacy/inference/deep_privacy_anonymizer.py
+++ b/deep_privacy/inference/deep_privacy_anonymizer.py
@@ -105,7 +105,7 @@ class DeepPrivacyAnonymizer(Anonymizer):
                     generated_faces = self.generator(im, keypoints)
                 results.append(generated_faces.cpu())
 
-        generated_faces = torch.cat(results)
+        generated_faces = torch.cat(results) if len(results) else torch.tensor([])
         return generated_faces
 
     def post_process(self, face_info, generated_faces, images):


### PR DESCRIPTION
Fix issue in case there is no faces to anonymise. 
This error was raised when `results` is empty here:https://github.com/hukkelas/DeepPrivacy/blob/acdf93777985169afb73a7d38cdd313efcb3ba68/deep_privacy/inference/deep_privacy_anonymizer.py#L81-L109

```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/conda/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/workspace/deep_privacy/inference/anonymize_folder.py", line 24, in <module>
    anonymizer.anonymize_folder(source_path, save_path)
  File "/workspace/deep_privacy/inference/anonymizer.py", line 37, in anonymize_folder
    im_bboxes=im_bboxes)
  File "/workspace/deep_privacy/inference/anonymizer.py", line 50, in anonymize_image_paths
    im_bboxes=im_bboxes)
  File "/workspace/deep_privacy/inference/deep_privacy_anonymizer.py", line 32, in anonymize_images
    generated_faces = self.anonymize_faces(face_info)
  File "/workspace/deep_privacy/inference/deep_privacy_anonymizer.py", line 108, in anonymize_faces
    generated_faces = torch.cat(results) # if len(results) else torch.tensor([])
RuntimeError: expected a non-empty list of Tensors
```