### PR TITLE
Allowing people to quickstart to use DeepPrivacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker build -t deep_privacy .
 
 We have a file command line interface to anonymize images.
 ```
-python3 anonymize.py --source_path input_image.png --target_path output_path.png
+python3 anonymize.py -s input_image.png -t output_path.png
 ```
 You can change the model with the "-m" or "--model" flag (see model zoo).
 The cli accepts image files, video files, and directories.

--- a/deep_privacy/build.py
+++ b/deep_privacy/build.py
@@ -17,11 +17,11 @@ available_models = [
 ]
 
 config_urls = {
-    "fdf128_retinanet512": "http://folk.ntnu.no/haakohu/configs/fdf/retinanet512.json",
-    "fdf128_retinanet256": "http://folk.ntnu.no/haakohu/configs/fdf/retinanet256.json",
-    "fdf128_retinanet128": "http://folk.ntnu.no/haakohu/configs/fdf/retinanet128.json",
-    "fdf128_rcnn512": "http://folk.ntnu.no/haakohu/configs/fdf_512.json",
-    "deep_privacy_V1": "http://folk.ntnu.no/haakohu/configs/deep_privacy_v1.json",
+    "fdf128_retinanet512": "https://folk.ntnu.no/haakohu/configs/fdf/retinanet512.json",
+    "fdf128_retinanet256": "https://folk.ntnu.no/haakohu/configs/fdf/retinanet256.json",
+    "fdf128_retinanet128": "https://folk.ntnu.no/haakohu/configs/fdf/retinanet128.json",
+    "fdf128_rcnn512": "https://folk.ntnu.no/haakohu/configs/fdf_512.json",
+    "deep_privacy_V1": "https://folk.ntnu.no/haakohu/configs/deep_privacy_v1.json",
 }
 
 

--- a/deep_privacy/inference/infer.py
+++ b/deep_privacy/inference/infer.py
@@ -43,6 +43,7 @@ def load_model_from_checkpoint(
     try:
         ckpt = get_checkpoint(cfg.output_dir, validation_checkpoint_step)
     except FileNotFoundError:
+        cfg.model_url = f'{cfg.model_url}'.replace("http://", "https://", 1)
         ckpt = None
         ckpt = load_checkpoint_from_url(cfg.model_url)
     if ckpt is None:

--- a/deep_privacy/metrics/metric_api.py
+++ b/deep_privacy/metrics/metric_api.py
@@ -4,7 +4,8 @@ import skimage.measure
 import torch
 import tqdm
 import multiprocessing
-from skimage.measure import compare_ssim, compare_psnr
+from skimage.metrics import structural_similarity as compare_ssim
+from skimage.metrics import peak_signal_noise_ratio as compare_psnr
 from .perceptual_similarity import PerceptualLoss
 from deep_privacy import torch_utils
 from .fid_pytorch import fid as fid_api

--- a/deep_privacy/metrics/metric_api.py
+++ b/deep_privacy/metrics/metric_api.py
@@ -4,8 +4,11 @@ import skimage.measure
 import torch
 import tqdm
 import multiprocessing
-from skimage.metrics import structural_similarity as compare_ssim
-from skimage.metrics import peak_signal_noise_ratio as compare_psnr
+try:
+    from skimage.measure import compare_ssim, compare_psnr
+except ImportError:
+    from skimage.metrics import structural_similarity as compare_ssim
+    from skimage.metrics import peak_signal_noise_ratio as compare_psnr
 from .perceptual_similarity import PerceptualLoss
 from deep_privacy import torch_utils
 from .fid_pytorch import fid as fid_api

--- a/deep_privacy/metrics/perceptual_similarity/__init__.py
+++ b/deep_privacy/metrics/perceptual_similarity/__init__.py
@@ -1,6 +1,9 @@
 
 import numpy as np
-from skimage.metrics import structural_similarity as compare_ssim
+try:
+    from skimage.measure import compare_ssim
+except ImportError:
+    from skimage.metrics import structural_similarity as compare_ssim
 import torch
 from torch.autograd import Variable
 

--- a/deep_privacy/metrics/perceptual_similarity/__init__.py
+++ b/deep_privacy/metrics/perceptual_similarity/__init__.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-from skimage.measure import compare_ssim
+from skimage.metrics import structural_similarity as compare_ssim
 import torch
 from torch.autograd import Variable
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+torch
+torchvision
+setuptools
+opencv-python
+numpy
+addict
+Pillow
+albumentations
+scipy
+scikit-image
+tqdm
+moviepy
+matplotlib
+scikit-learn>=0.2
+pandas

--- a/webcam.py
+++ b/webcam.py
@@ -31,7 +31,7 @@ else:
 frames = 0
 WARMUP = True
 t = time.time()
-while(True):
+while True:
     # Capture frame-by-frame
     ret, frame = cap.read()
     frame = cv2.resize(frame, (width, height))

--- a/webcam.py
+++ b/webcam.py
@@ -7,6 +7,7 @@ from deep_privacy import cli
 from deep_privacy.visualization import utils as vis_utils
 from deep_privacy.utils import BufferlessVideoCapture
 from deep_privacy.build import build_anonymizer
+import os
 # Configs
 torch.backends.cudnn.benchmark = False
 parser = cli.get_parser()


### PR DESCRIPTION
closes #41, #42 
- I added a requirements.txt so people are not left to test for what to install
- I allowed newer versions of scikit-image to run, as well as allowing the older versions to run 
- I allowed the downloader to work, as it was not able to handle redirects from http to https
All of these will allow users to run DeepPrivacy easier.
I do not need to be credited for helping, I wanted to test this out, and I was having similar problems to others.