### PR TITLE
Add face_detection dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ moviepy
 matplotlib
 scikit-learn>=0.2
 pandas
+face_detection


### PR DESCRIPTION
`requirements.txt` lacks `face_detection` dependency.
Trying to run project without it leads to `ModuleNotFoundError: No module named 'face_detection'` error.

`face_detection` is imported [here](https://github.com/hukkelas/DeepPrivacy/blob/cf1e0ed81a45eb9b41a178ae100260842de64dc0/deep_privacy/detection/detection_api.py#L4)
