### PR TITLE
CLI: Allow directories as target path

### DIFF
--- a/deep_privacy/cli.py
+++ b/deep_privacy/cli.py
@@ -27,11 +27,15 @@ def get_target_paths(source_paths: typing.List[pathlib.Path],
                      default_dir: pathlib.Path):
     if not target_path is None:
         target_path = pathlib.Path(target_path)
-        assert len(source_paths) == 1, \
-            f"Target path is 1 file, but expected several inputs" + \
-            f"target path={target_path}, source_path={source_paths}"
-        target_path.parent.mkdir(exist_ok=True)
-        return [target_path]
+        if len(source_paths) > 1:
+            target_path.mkdir(exist_ok=True, parents=True)
+            target_paths = []
+            for source_path in source_paths:
+                target_paths.append(target_path.joinpath(source_path.name))
+            return target_paths
+        else:
+            target_path.parent.mkdir(exist_ok=True)
+            return [target_path]
     logger.info(
         f"Found no target path. Setting to default output path: {default_dir}")
     default_target_dir = default_dir


### PR DESCRIPTION
Currently, while the CLI does allow directories as sources for anonymizations, it does not as targets.
This means that when all images from a directory are anonymized, only the default (fallback) path can be used.

This PR adds this functionality.
When multiple source paths are used and a target path specified, this target path is assumed to be a directory and the anonymized files will be placed in it (preserving the original file name).
This does not change current behavior. It only adds support for a case that previously error-ed out because of an assert.

We would appreciate it, if this enhancement could be merged as it adds a useful feature (for example in our usecase).
Thank you in advance!